### PR TITLE
Feat/timer

### DIFF
--- a/src/features/timer/components/TimerDisplay.tsx
+++ b/src/features/timer/components/TimerDisplay.tsx
@@ -1,0 +1,78 @@
+import type { FC } from 'react'
+import { LuPlay, LuPause, LuRefreshCcw } from 'react-icons/lu'
+import type { TimerDisplayProps } from '../hooks/types'
+
+export const TimerDisplay: FC<TimerDisplayProps> = ({
+  isRunning,
+  timeLeft,
+  isWorkSession,
+  sessionsCompleted,
+  formatTime,
+  onStart,
+  onStop,
+  onReset,
+}) => {
+  return (
+    <div className="col-span-10 lg:col-span-3 bg-white rounded-lg p-6 shadow-md border border-gray-200">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-bold text-gray-900">52/17 rule</h2>
+        <span className="text-xs bg-green-100 text-green-700 px-3 py-1 rounded-full">
+          Completed: {sessionsCompleted}
+        </span>
+      </div>
+
+      <div className="bg-gray-50 rounded-lg p-6 mb-4 text-center border border-gray-200">
+        <div className="text-4xl font-bold text-gray-900 mb-1 font-mono">
+          {formatTime(timeLeft)}
+        </div>
+        <p className="text-gray-600 text-sm">{isWorkSession ? 'Working' : 'Break'}</p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 mb-4">
+        <div
+          className={`rounded-lg p-2 border text-center ${
+            isWorkSession ? 'bg-blue-50 border-blue-200' : 'bg-gray-50 border-gray-200'
+          }`}
+        >
+          <p className={`text-xs mb-1 font-semibold ${isWorkSession ? 'text-blue-700' : 'text-gray-600'}`}>
+            Focus
+          </p>
+          <p className="text-gray-900 font-bold">52 min</p>
+        </div>
+        <div
+          className={`rounded-lg p-2 border text-center ${
+            !isWorkSession ? 'bg-green-50 border-green-200' : 'bg-gray-50 border-gray-200'
+          }`}
+        >
+          <p className={`text-xs mb-1 font-semibold ${!isWorkSession ? 'text-green-700' : 'text-gray-600'}`}>
+            Break
+          </p>
+          <p className="text-gray-900 font-bold">17 min</p>
+        </div>
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          onClick={onStart}
+          disabled={isRunning}
+          className="flex-1 bg-blue-500 hover:bg-blue-600 disabled:bg-blue-300 text-white font-semibold py-3 rounded-lg transition-colors text-sm flex items-center justify-center"
+        >
+          <LuPlay size={20} />
+        </button>
+        <button
+          onClick={onStop}
+          disabled={!isRunning}
+          className="flex-1 bg-gray-400 hover:bg-gray-500 disabled:bg-gray-200 text-white font-semibold py-3 rounded-lg transition-colors text-sm flex items-center justify-center"
+        >
+          <LuPause size={20} />
+        </button>
+        <button
+          onClick={onReset}
+          className="flex-1 bg-gray-400 hover:bg-gray-500 text-white font-semibold py-3 rounded-lg transition-colors text-sm flex items-center justify-center"
+        >
+          <LuRefreshCcw size={20} />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/features/timer/containers/Timer.tsx
+++ b/src/features/timer/containers/Timer.tsx
@@ -1,0 +1,29 @@
+import type { FC } from 'react'
+import { useTimer } from '../hooks/useTimer'
+import { TimerDisplay } from '../components/TimerDisplay'
+
+export const Timer: FC = () => {
+  const {
+    isRunning,
+    timeLeft,
+    isWorkSession,
+    sessionsCompleted,
+    handleStart,
+    handleStop,
+    handleReset,
+    formatTime,
+  } = useTimer()
+
+  return (
+    <TimerDisplay
+      isRunning={isRunning}
+      timeLeft={timeLeft}
+      isWorkSession={isWorkSession}
+      sessionsCompleted={sessionsCompleted}
+      formatTime={formatTime}
+      onStart={handleStart}
+      onStop={handleStop}
+      onReset={handleReset}
+    />
+  )
+}

--- a/src/features/timer/hooks/constants.ts
+++ b/src/features/timer/hooks/constants.ts
@@ -1,0 +1,2 @@
+export const WORK_TIME = 52 * 60;
+export const BREAK_TIME = 17 * 60;

--- a/src/features/timer/hooks/types.ts
+++ b/src/features/timer/hooks/types.ts
@@ -1,0 +1,24 @@
+export interface TimerDisplayProps {
+  isRunning: boolean;
+  timeLeft: number;
+  isWorkSession: boolean;
+  sessionsCompleted: number;
+  formatTime: (seconds: number) => string;
+  onStart: () => void;
+  onStop: () => void;
+  onReset: () => void;
+}
+
+export interface TimerState {
+  isRunning: boolean;
+  timeLeft: number;
+  isWorkSession: boolean;
+  sessionsCompleted: number;
+}
+
+export interface TimerHandlers {
+  handleStart: () => void;
+  handleStop: () => void;
+  handleReset: () => void;
+  formatTime: (seconds: number) => string;
+}

--- a/src/features/timer/hooks/useTimer.ts
+++ b/src/features/timer/hooks/useTimer.ts
@@ -1,0 +1,114 @@
+import { useState, useEffect } from "react";
+import { WORK_TIME, BREAK_TIME } from "./constants";
+
+export const useTimer = () => {
+  const [isRunning, setIsRunning] = useState(false);
+  const [timeLeft, setTimeLeft] = useState(WORK_TIME);
+  const [isWorkSession, setIsWorkSession] = useState(true);
+  const [sessionsCompleted, setSessionsCompleted] = useState(0);
+  const [sessionStart, setSessionStart] = useState<number | null>(null);
+  const [pausedTime, setPausedTime] = useState<number | null>(null);
+
+  const playAlert = () => {
+    const audioContext = new (window.AudioContext ||
+      (window as any).webkitAudioContext)();
+    const oscillator = audioContext.createOscillator();
+    const gainNode = audioContext.createGain();
+
+    oscillator.connect(gainNode);
+    gainNode.connect(audioContext.destination);
+
+    oscillator.frequency.value = 800;
+    oscillator.type = "sine";
+
+    gainNode.gain.setValueAtTime(0.3, audioContext.currentTime);
+    gainNode.gain.exponentialRampToValueAtTime(
+      0.01,
+      audioContext.currentTime + 0.5
+    );
+
+    oscillator.start(audioContext.currentTime);
+    oscillator.stop(audioContext.currentTime + 0.5);
+  };
+
+  useEffect(() => {
+    if (!isRunning) {
+      if (sessionStart && pausedTime === null) {
+        setPausedTime(Date.now());
+      }
+      return;
+    }
+
+    const now = Date.now();
+    let actualSessionStart = sessionStart;
+
+    if (!actualSessionStart) {
+      actualSessionStart = now;
+      setSessionStart(now);
+    } else if (pausedTime) {
+      const pauseDuration = now - pausedTime;
+      actualSessionStart = actualSessionStart + pauseDuration;
+      setSessionStart(actualSessionStart);
+      setPausedTime(null);
+    }
+
+    const sessionDuration = isWorkSession ? WORK_TIME : BREAK_TIME;
+
+    const interval = setInterval(() => {
+      const elapsed = Math.floor((Date.now() - actualSessionStart) / 1000);
+      const remaining = sessionDuration - elapsed;
+
+      if (remaining <= 0) {
+        playAlert();
+        if (isWorkSession) {
+          setSessionsCompleted((s) => s + 1);
+          setIsWorkSession(false);
+        } else {
+          setIsWorkSession(true);
+        }
+        setSessionStart(null);
+        setPausedTime(null);
+      } else {
+        setTimeLeft(remaining);
+      }
+    }, 100);
+
+    return () => clearInterval(interval);
+  }, [isRunning, isWorkSession]);
+
+  const handleStart = () => {
+    setIsRunning(true);
+  };
+
+  const handleStop = () => {
+    setIsRunning(false);
+  };
+
+  const handleReset = () => {
+    setIsRunning(false);
+    setTimeLeft(WORK_TIME);
+    setIsWorkSession(true);
+    setSessionsCompleted(0);
+    setSessionStart(null);
+    setPausedTime(null);
+  };
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins.toString().padStart(2, "0")}:${secs
+      .toString()
+      .padStart(2, "0")}`;
+  };
+
+  return {
+    isRunning,
+    timeLeft,
+    isWorkSession,
+    sessionsCompleted,
+    handleStart,
+    handleStop,
+    handleReset,
+    formatTime,
+  };
+};

--- a/src/features/timer/index.ts
+++ b/src/features/timer/index.ts
@@ -1,0 +1,2 @@
+export { Timer } from './containers/Timer'
+export { useTimer } from './hooks/useTimer'

--- a/src/pages/dashboard/components/TopSection.tsx
+++ b/src/pages/dashboard/components/TopSection.tsx
@@ -1,20 +1,25 @@
 import type { FC } from 'react'
+import { useState, useEffect } from 'react'
+import { Timer } from '../../../features/timer'
 
 const TopSection: FC = () => {
-  const generateContributionData = () => {
-    const weeks = Math.ceil(365 / 7)
-    const data = []
-    for (let i = 0; i < weeks; i++) {
-      const week = []
-      for (let j = 0; j < 7; j++) {
-        week.push(Math.floor(Math.random() * 5))
-      }
-      data.push(week)
-    }
-    return data
-  }
+  const [contributionData, setContributionData] = useState<number[][]>([])
 
-  const contributionData = generateContributionData()
+  useEffect(() => {
+    const generateContributionData = () => {
+      const weeks = Math.ceil(365 / 7)
+      const data = []
+      for (let i = 0; i < weeks; i++) {
+        const week = []
+        for (let j = 0; j < 7; j++) {
+          week.push(Math.floor(Math.random() * 5))
+        }
+        data.push(week)
+      }
+      return data
+    }
+    setContributionData(generateContributionData())
+  }, [])
 
   const languages = [
     { name: 'JavaScript', percentage: 35, color: 'bg-yellow-400' },
@@ -113,44 +118,7 @@ const TopSection: FC = () => {
         </div>
       </div>
 
-      <div className="col-span-10 lg:col-span-3 bg-white rounded-lg p-6 shadow-md border border-gray-200">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-bold text-gray-900">⏱️ ポモドーロ</h2>
-          <span className="text-xs bg-blue-100 text-blue-700 px-3 py-1 rounded-full">
-            準備中
-          </span>
-        </div>
-
-        <div className="bg-gray-50 rounded-lg p-6 mb-4 text-center border border-gray-200">
-          <div className="text-4xl font-bold text-gray-900 mb-1 font-mono">
-            25:00
-          </div>
-          <p className="text-gray-600 text-sm">作業中</p>
-        </div>
-
-        <div className="grid grid-cols-2 gap-2 mb-4">
-          <div className="bg-blue-50 rounded-lg p-2 border border-blue-200 text-center">
-            <p className="text-blue-700 text-xs mb-1 font-semibold">作業</p>
-            <p className="text-gray-900 font-bold">25分</p>
-          </div>
-          <div className="bg-green-50 rounded-lg p-2 border border-green-200 text-center">
-            <p className="text-green-700 text-xs mb-1 font-semibold">休憩</p>
-            <p className="text-gray-900 font-bold">5分</p>
-          </div>
-        </div>
-
-        <div className="flex gap-2">
-          <button className="flex-1 bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 rounded-lg transition-colors text-sm">
-            ▶
-          </button>
-          <button className="flex-1 bg-gray-300 hover:bg-gray-400 text-gray-900 font-semibold py-2 rounded-lg transition-colors text-sm">
-            ⏸
-          </button>
-          <button className="flex-1 bg-gray-300 hover:bg-gray-400 text-gray-900 font-semibold py-2 rounded-lg transition-colors text-sm">
-            🔄
-          </button>
-        </div>
-      </div>
+      <Timer />
     </div>
   )
 }


### PR DESCRIPTION
## 概要
対応PR：Issue #

## 対応内容
- Web Audio APIで音声アラート機能を追加
- タイムスタンプベースのカウント実装（バックグラウンド対応）
- 停止/再開時に残り時間を保持
- 52分作業 → 17分休憩の自動切り替え
- features/pomodoro → features/timer にリネーム
- コンポーネント・フック・型を整理
- constants.ts, types.ts を hooks/ 配下に移動

## 目的
- 52/17ルール（52分作業/17分休憩）に基づいた学習タイマーの実装
- バックグラウンドでも正確に動作し、ユーザーが中断・再開しても残り時間を保持する堅牢な実装を実現する

## 動作確認方法
1. ブラウザで `http://localhost:5173` にアクセス
  2. 52/17 rule タイマーの「再生」ボタンを押してタイマーが動作することを確認
  3. 「停止」ボタンで一時停止後、「再生」を押して残り時間から継続されることを確認
  4. タイマーをバックグラウンドに移して、ブラウザタブを切り替えた状態で時間経過を確認
  5. セッション終了時（52分または17分）に音声アラートが鳴ることを確認
  6. 「リセット」ボタンで初期状態に戻されることを確認

## スクリーンショット / 動作イメージ（あれば）
<画像 or GIF>

## 備考
-